### PR TITLE
Singleton class syntax support

### DIFF
--- a/lib/yard-sorbet/sig_handler.rb
+++ b/lib/yard-sorbet/sig_handler.rb
@@ -24,6 +24,7 @@ class YARDSorbet::SigHandler < YARD::Handlers::Ruby::Base
 
       next_statement = class_contents[i + 1]
       next unless processable_method?(next_statement)
+
       process_method_definition(next_statement, child)
     end
   end

--- a/lib/yard-sorbet/sig_handler.rb
+++ b/lib/yard-sorbet/sig_handler.rb
@@ -11,7 +11,7 @@ class YARDSorbet::SigHandler < YARD::Handlers::Ruby::Base
     class_def = statement.children.find { |c| c.type == :list }
     class_contents = class_def.children
     class_contents.each_with_index do |child, i|
-      if child.type == :sclass && child.children.size == 2
+      if child.type == :sclass && child.children.size == 2 && child.children[1].type == :list
         singleton_class_contents = child.children[1]
         singleton_class_contents.each_with_index do |child, j|
           handle_class_contents(singleton_class_contents, j)

--- a/lib/yard-sorbet/sig_handler.rb
+++ b/lib/yard-sorbet/sig_handler.rb
@@ -10,49 +10,53 @@ class YARDSorbet::SigHandler < YARD::Handlers::Ruby::Base
     # Find the list of declarations inside the class
     class_def = statement.children.find { |c| c.type == :list }
     class_contents = class_def.children
+
+    process_class_contents(class_contents)
+  end
+
+  private def process_class_contents(class_contents)
     class_contents.each_with_index do |child, i|
       if child.type == :sclass && child.children.size == 2 && child.children[1].type == :list
         singleton_class_contents = child.children[1]
-        singleton_class_contents.each_with_index do |child, j|
-          handle_class_contents(singleton_class_contents, j)
-        end
+        process_class_contents(singleton_class_contents)
       end
+      next unless type_signature?(child)
 
-      handle_class_contents(class_contents, i)
+      next_statement = class_contents[i + 1]
+      next unless processable_method?(next_statement)
+      process_method_definition(next_statement, child)
     end
   end
 
-  private def handle_class_contents(class_contents, i)
-    child = class_contents[i]
-    return unless type_signature?(child)
+  private def processable_method?(next_statement)
+    %i[def defs command].include?(next_statement&.type) && !next_statement.docstring
+  end
 
-    next_statement = class_contents[i + 1]
-    if %i[def defs command].include?(next_statement&.type) && !next_statement.docstring
-      # Swap the method definition docstring and the sig docstring.
-      # Parse relevant parts of the `sig` and include them as well.
-      parser = YARD::DocstringParser.new.parse(child.docstring)
-      # Directives are already parsed at this point, and there doesn't
-      # seem to be an API to tweeze them from one node to another without
-      # managing YARD internal state. Instead, we just extract them from
-      # the raw text and re-attach them.
-      directives = parser.raw_text&.split("\n")&.select do |line|
-        line.start_with?('@!')
-      end || []
-      docstring = parser.to_docstring
-      parsed_sig = parse_sig(child)
-      enhance_tag(docstring, :abstract, parsed_sig)
-      enhance_tag(docstring, :return, parsed_sig)
-      if next_statement.type != :command
-        parsed_sig[:params]&.each do |name, types|
-          enhance_param(docstring, name, types)
-        end
+  private def process_method_definition(method_node, sig_node)
+    # Swap the method definition docstring and the sig docstring.
+    # Parse relevant parts of the `sig` and include them as well.
+    parser = YARD::DocstringParser.new.parse(sig_node.docstring)
+    # Directives are already parsed at this point, and there doesn't
+    # seem to be an API to tweeze them from one node to another without
+    # managing YARD internal state. Instead, we just extract them from
+    # the raw text and re-attach them.
+    directives = parser.raw_text&.split("\n")&.select do |line|
+      line.start_with?('@!')
+    end || []
+    docstring = parser.to_docstring
+    parsed_sig = parse_sig(sig_node)
+    enhance_tag(docstring, :abstract, parsed_sig)
+    enhance_tag(docstring, :return, parsed_sig)
+    if method_node.type != :command
+      parsed_sig[:params]&.each do |name, types|
+        enhance_param(docstring, name, types)
       end
-      next_statement.docstring = docstring.to_raw
-      directives.each do |directive|
-        next_statement.docstring.concat("\n#{directive}")
-      end
-      child.docstring = nil
     end
+    method_node.docstring = docstring.to_raw
+    directives.each do |directive|
+      method_node.docstring.concat("\n#{directive}")
+    end
+    sig_node.docstring = nil
   end
 
   private def enhance_param(docstring, name, types)

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe YARDSorbet::SigHandler do
     end
 
     it 'handles singleton class syntax' do
-      skip('TODO')
       node = YARD::Registry.at('Signatures.reopening')
       expect(node.docstring).to eq('comment reopening')
     end


### PR DESCRIPTION
Having yard documentation combined with a sig inside the singleton class syntax, `class << self`, was giving the following warning:

`[warn]: in YARD::Handlers::Ruby::DSLHandler: Undocumentable method, missing name`

This PR aims to support singleton class syntax by handling the class definition of the singleton similar to before. In the previous implementation singleton class's contents were skipped as it's not of type `list`. Here in the `#process` method we explicitly call the existing handler logic if we encounter a singleton class.

Most of the diff is due to moving the handler logic into a separate function.

I tested more extensively locally but in terms of the PR I only unskipped the existing test. If wanted I can add more complex cases.
