### PR TITLE
Provide support for top_const_ref nodes

### DIFF
--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -79,7 +79,7 @@ module YARDSorbet::SigToYARD
         [node.source]
       end
     when :top_const_ref
-      # Node from a user defined type with a double colon, ::Klass
+      # A top-level constant reference, such as ::Klass
       # It contains a child node of type :const
       convert(children.first)
     when :const

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -78,6 +78,12 @@ module YARDSorbet::SigToYARD
       else
         [node.source]
       end
+    when :top_const_ref
+      # Node from a user defined type with a double colon, ::Klass
+      # It contains a child node of type :const
+      convert(children.first)
+    when :const
+      [node.source]
     else
       log.warn("Unsupported sig #{node.type} node #{node.source}")
       [node.source]

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -56,7 +56,7 @@ module YARDSorbet::SigToYARD
       else
         [node.source]
       end
-    when :const_path_ref
+    when :const_path_ref, :const
       [node.source]
     when :hash, :list
       # Fixed hashes as return values are unsupported:
@@ -82,8 +82,6 @@ module YARDSorbet::SigToYARD
       # A top-level constant reference, such as ::Klass
       # It contains a child node of type :const
       convert(children.first)
-    when :const
-      [node.source]
     else
       log.warn("Unsupported sig #{node.type} node #{node.source}")
       [node.source]

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -184,6 +184,62 @@ class CollectionSigs
   def fixed_param_hash(tos_acceptance); nil; end
 end
 
+class VariousTypedSigs
+  sig { returns(String) }
+  def arg_paren; end
+
+  sig { returns([String]) }
+  def array; end
+
+  sig { returns(T.all(Foo, Bar)) }
+  def call_T_all; end
+
+  sig { returns(T.class_of(String)) }
+  def call_T_class_of; String; end
+
+  sig { returns(T.enum) }
+  def call_T_enum; end
+
+  sig { returns(T.noreturn) }
+  def call_T_noreturn; end
+
+  sig { returns(T.self_type) }
+  def call_T_self_type; end
+
+  sig { returns(T.type_parameter) }
+  def call_T_type_parameter; end
+
+  sig { returns(T.untyped) }
+  def call_T_untyped; end
+
+  sig { returns(T.any(Integer, String)) }
+  def call_T_any; end
+
+  sig { returns(T.nilable(String)) }
+  def call_T_nilable; end
+
+  sig { returns(Foo::Bar) }
+  def const_path_ref; end
+
+  sig { returns( {foo: 1} ) }
+  def hash; end
+
+  sig { returns(FalseClass) }
+  def var_ref_false_class; end
+
+  sig { returns(NilClass) }
+  def var_ref_nil_class; end
+
+  sig { returns(TrueClass) }
+  def var_ref_true_class; end
+
+  sig { returns(Foo) }
+  def var_ref; end
+
+  sig { returns(::Foo) }
+  def top_const_ref; end
+end
+
 class AttrSigs
   sig {returns(String)}
   attr_accessor :my_accessor

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -206,6 +206,96 @@ RSpec.describe YARDSorbet::SigHandler do
       param_tag = node.tags.find { |t| t.name == 'tos_acceptance' }
       expect(param_tag.types).to eq(%w[Hash nil])
     end
+
+    it 'arg_paren' do
+      node = YARD::Registry.at('VariousTypedSigs#arg_paren')
+      expect(node.tag(:return).types).to eq(['String'])
+    end
+
+    it 'array' do
+      node = YARD::Registry.at('VariousTypedSigs#array')
+      expect(node.tag(:return).types).to eq(['Array(String)'])
+    end
+
+    it 'call_T_all' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_all')
+      expect(node.tag(:return).types).to eq(['T.all(Foo, Bar)'])
+    end
+
+    it 'call_T_class_of' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_class_of')
+      expect(node.tag(:return).types).to eq(['T.class_of(String)'])
+    end
+
+    it 'call_T_enum' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_enum')
+      expect(node.tag(:return).types).to eq(['T.enum'])
+    end
+
+    it 'call_T_noreturn' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_noreturn')
+      expect(node.tag(:return).types).to eq(['T.noreturn'])
+    end
+
+    it 'call_T_self_type' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_self_type')
+      expect(node.tag(:return).types).to eq(['T.self_type'])
+    end
+
+    it 'call_T_type_parameter' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_type_parameter')
+      expect(node.tag(:return).types).to eq(['T.type_parameter'])
+    end
+
+    it 'call_T_untyped' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_untyped')
+      expect(node.tag(:return).types).to eq(['T.untyped'])
+    end
+
+    it 'call_T_any' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_any')
+      expect(node.tag(:return).types).to eq(['Integer', 'String'])
+    end
+
+    it 'call_T_nilable' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_nilable')
+      expect(node.tag(:return).types).to eq(['String', 'nil'])
+    end
+
+    it 'const_path_ref' do
+      node = YARD::Registry.at('VariousTypedSigs#const_path_ref')
+      expect(node.tag(:return).types).to eq(['Foo::Bar'])
+    end
+
+    it 'hash' do
+      node = YARD::Registry.at('VariousTypedSigs#hash')
+      expect(node.tag(:return).types).to eq(['Hash'])
+    end
+
+    it 'var_ref_false_class' do
+      node = YARD::Registry.at('VariousTypedSigs#var_ref_false_class')
+      expect(node.tag(:return).types).to eq(['false'])
+    end
+
+    it 'var_ref_nil_class' do
+      node = YARD::Registry.at('VariousTypedSigs#var_ref_nil_class')
+      expect(node.tag(:return).types).to eq(['nil'])
+    end
+
+    it 'var_ref_true_class' do
+      node = YARD::Registry.at('VariousTypedSigs#var_ref_true_class')
+      expect(node.tag(:return).types).to eq(['true'])
+    end
+
+    it 'var_ref' do
+      node = YARD::Registry.at('VariousTypedSigs#var_ref')
+      expect(node.tag(:return).types).to eq(['Foo'])
+    end
+
+    it 'top_const_ref' do
+      node = YARD::Registry.at('VariousTypedSigs#top_const_ref')
+      expect(node.tag(:return).types).to eq(['Foo'])
+    end
   end
 
   describe 'attributes' do


### PR DESCRIPTION
Came across these nodes when using sigs that contain `::Klass` syntax to represent user defined types.