### PR TITLE
Disable warning for attached_class

### DIFF
--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -40,7 +40,7 @@ module YARDSorbet::SigToYARD
       if children[0].source == 'T'
         t_method = IS_LEGACY_RUBY_VERSION ? children[1].source : children[2].source
         case t_method
-        when 'all', 'class_of', 'enum', 'noreturn', 'self_type', 'type_parameter', 'untyped'
+        when 'all', 'attached_class','class_of', 'enum', 'noreturn', 'self_type', 'type_parameter', 'untyped'
           # YARD doesn't have equivalent notions, so we just use the raw source
           [node.source]
         when 'any'


### PR DESCRIPTION
Usages of `T.attached_class` is currently producing a warning. As far as I know it doesn't have an equivalent YARD representation and can be included in this list instead of producing a warning.